### PR TITLE
convert to new plugin2 style

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ WriteMakefile(
     PL_FILES         => {},
     PREREQ_PM => {
         'Test::More' => 0,
-        'Dancer2'    => 0.164000,
+        'Dancer2'    => '0.166002',
         'Digest::Bcrypt' => 0,
         'Digest::SHA' => 5.74,
         'Data::Entropy' => 0.007,

--- a/lib/Dancer2/Plugin/Passphrase.pm
+++ b/lib/Dancer2/Plugin/Passphrase.pm
@@ -3,13 +3,13 @@ package Dancer2::Plugin::Passphrase;
 use 5.010001;
 use strict;
 use warnings;
-use Dancer2::Plugin;
 use Dancer2::Plugin::Passphrase::Core;
 use Dancer2::Plugin::Passphrase::Hashed;
+use Dancer2::Plugin;
 
 our $VERSION = '3.2.2';
 
-register passphrase => \&passphrase;
+plugin_keywords 'passphrase';
 
 # ABSTRACT: Passphrases and Passwords as objects for Dancer2
 
@@ -73,26 +73,20 @@ object that you can generate a new hash from, or match against a stored hash.
 
 =cut
 
-my $settings = {};
-
-on_plugin_import {
-    $settings  = plugin_setting()
-        unless $settings->{'algorithm'};
-    $settings->{'algorithm'} = 'Bcrypt';
-};
+has algorithm => (
+    is          => 'ro',
+    from_config => sub { 'Bcrypt' },
+);
 
 sub passphrase {
-    my ($dsl, $plaintext) = @_;
+    my ($plugin, $plaintext) = @_;
 
     return Dancer2::Plugin::Passphrase::Core->new(
-        algorithm => $settings->{'algorithm'},
+        %{$plugin->config},
+        algorithm => $plugin->algorithm,
         plaintext => $plaintext,
-
-        %{$settings},
     );
 }
-
-register_plugin;
 
 1;
 
@@ -329,7 +323,7 @@ a strong psuedo-random salt.
 
     plugins:
         Passphrase:
-            default: Bcrypt
+            algorithm: Bcrypt
 
             Bcrypt:
                 cost: 8
@@ -469,7 +463,7 @@ Maintainer: Henk van Oers <hvoers@cpan.org>
 
 =head1 COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2012 by James Aitken.
+This software is copyright (c) 2012-2016 by James Aitken.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.


### PR DESCRIPTION
This means that this plugin is no longer compatible with Dancer versions <= 0.166001. Dancer2 dependency will be updated once the next release version is known and then this plugin should be released to CPAN immediately after then next Dancer2 release.
    
This change is needed since this plugin is used by another plugin Dancer2::Plugin::Auth::Extensible::Provider::Usergroup) and so must be fully compliant with plugin2 before this other plugin can work with plugin2.